### PR TITLE
Refactor writeContentsFile to handle embargo permissions

### DIFF
--- a/dspacearchive.py
+++ b/dspacearchive.py
@@ -85,12 +85,47 @@ class DspaceArchive:
     """
     Create a contents file that contains a lits of bitstreams, one per line. 
     """
+    """Commenting out original contents file creation
     def writeContentsFile(self, item, item_path):
         contents_file = open(os.path.join(item_path, b'contents'), "wb")
 
         files = item.getFiles()
         for index, file_name in enumerate(files):
             contents_file.write(self.normalizeUnicode(file_name))
+            if index < len(files):
+                contents_file.write(b"\n")
+
+        contents_file.close()
+    Remove these comments to reinstate"""
+
+    """
+        Create a contents file that contains a list of bitstreams, one per line. 
+        Appends Administrator permissions if an embargo date is present.
+        """
+    def writeContentsFile(self, item, item_path):
+        contents_file = open(os.path.join(item_path, b'contents'), "wb")
+
+        # 1. Check if the item contains a value for dc.date.embargo
+        attributes = item.getAttributes()
+        has_embargo = False
+        
+        if b'dc.date.embargo' in attributes:
+            embargo_value = attributes[b'dc.date.embargo']
+            # Ensure the value isn't just an empty string or whitespace
+            if embargo_value and embargo_value.strip():
+                has_embargo = True
+
+        # 2. Iterate through the bitstreams
+        files = item.getFiles()
+        for index, file_name in enumerate(files):
+            # Write the file name
+            contents_file.write(self.normalizeUnicode(file_name))
+            
+            # 3. Append the permissions string if an embargo is detected
+            if has_embargo:
+                contents_file.write(b"\tpermissions: -[r|w] 'Administrator'")
+                    
+            # Add a newline character
             if index < len(files):
                 contents_file.write(b"\n")
 


### PR DESCRIPTION
I wanted to offer this as a suggestion because we are new to DSpace and the dspace-csv-archive tool has been very useful for us! But it didn't handle embargos as far as I could tell.

Commented out the original contents file creation and added logic to handle embargo permissions for bitstreams:

If a work in the CSV has a value under the dc.date.embargo column, this adds a permission flag to the bitstream line in the contents file. This will allow administrators access to the bitstream in DSpace and set the embargo date based on the date in dc.date.embargo. The work metadata page will be unaffected, but the bitstream download will be hidden until the embargo date.

<img width="1404" height="158" alt="Screenshot 2026-05-22 134906" src="https://github.com/user-attachments/assets/b2d12286-7e52-4401-89a9-5d0efa000d2c" />
